### PR TITLE
Fix TypeScript params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-graphql",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "description": "Create Apollo DataSource to connect to a GraphQL API",
   "main": "dist/index.js",

--- a/src/GraphQLDataSource.ts
+++ b/src/GraphQLDataSource.ts
@@ -16,12 +16,12 @@ export class GraphQLDataSource<TContext = any> {
     this.context = config.context;
   }
 
-  public async mutation(mutation: DocumentNode, options: GraphQLRequest) {
+  public async mutation(mutation: DocumentNode, options?: GraphQLRequest) {
     // GraphQL request requires the DocumentNode property to be named query
     return this.executeSingleOperation({ ...options, query: mutation });
   }
 
-  public async query(query: DocumentNode, options: GraphQLRequest) {
+  public async query(query: DocumentNode, options?: GraphQLRequest) {
     return this.executeSingleOperation({ ...options, query });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { GraphQLDataSource } from './GraphQLDataSource';
+export { GraphQLDataSource as default, GraphQLDataSource } from './GraphQLDataSource';


### PR DESCRIPTION
- Make `options` param in `query`/`mutation` methods optional
- Export `GraphQLDataSource` as both default and named